### PR TITLE
fix: channel_remap missing in envs.txt

### DIFF
--- a/constructor/preconda.py
+++ b/constructor/preconda.py
@@ -154,7 +154,7 @@ def write_files(info, dst_dir):
 
     # base environment file used with conda install --file
     # (list of specs/dists to install)
-    write_env_txt(info, dst_dir, info["_urls"])
+    write_env_txt(info, dst_dir, final_urls_md5s)
 
     for fn in files:
         os.chmod(join(dst_dir, fn), 0o664)
@@ -167,7 +167,7 @@ def write_files(info, dst_dir):
         user_requested_specs = env_config.get('user_requested_specs', env_config.get('specs', ()))
         write_conda_meta(info, env_dst_dir, env_urls_md5, user_requested_specs)
         # environment installation list
-        write_env_txt(info, env_dst_dir, env_info["_urls"])
+        write_env_txt(info, env_dst_dir, env_urls_md5)
         # channels
         write_channels_txt(info, env_dst_dir, env_config)
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The change for @#559 breaks functionality of channel_remap.

When using channel_remap (remap build time channels to new ones at install time) the generated URLS in envs.txt do not use channel_remap, so envs.txt and urls.txt differ --> conda tries to find the packages within the original channel given at build time, which does usually not exist at install site.

Before @#559 there was only package name in envs.txt, so remapped url was only required within urls.txt and channel_remap was okay.

This is a minor fix.

### Test for this

No automatic test provided, but the effort should be small, and even possible without real private package:

- create construct.yaml with small amount of packages
- provide packages within folder linux-64 of `channel_remap` src folder (the local channel will be searched first)
- create repo by calling `conda index <remap src folder>`
- use following channel config in contruct.yaml (replace file:/// by your path to local channel):

```
channels:
  - file:///home/winkler/pythonrepo
  - conda-forge
channels_remap:
  - src: file:///home/winkler/pythonrepo
    dest: https://conda.anaconda.org/conda-forge/
```
(the remap dest conda-forge is just used as an example)

Now try to use the generated installer; if fails, inspect `<install prefix>/pkgs/envs.txt`. Here the file path from build is included instead the remapped path from urls.txt.

